### PR TITLE
Fix getUser method

### DIFF
--- a/ldap.production.js
+++ b/ldap.production.js
@@ -21,7 +21,7 @@ module.exports = function (ldapConfig) {
     getUserGroups: getUserGroups,
     getAllUsers: function (callback) { ad.getUsersForGroup(allUserGroup, callback) },
     getUserEmail: getUserEmail,
-    getUser: ad.findUser,
+    getUser: function (username, callback) { ad.findUser(username, callback) },
     getAllManagers: function (callback) { ad.getUsersForGroup(managerGroup, callback) }
   }
 }


### PR DESCRIPTION
Scope issues, needed to wrap ad.findUser in a callback in order to preserve the ad variable and its credentials.

@anotheredward pls review
